### PR TITLE
fix: check if `clangd` located on `PATH` is already the correct one

### DIFF
--- a/lua/esp32/init.lua
+++ b/lua/esp32/init.lua
@@ -37,6 +37,17 @@ end
 
 --- Find the ESP-IDF specific clangd
 function M.find_esp_clangd()
+	-- if clangd is on the path, check if it is from espressif using.
+	-- if so, we are done
+	if vim.fn.executable("clangd") == 1 then
+		-- use `clangd --version` to check if it is from espressif
+		local clangd_version = vim.fn.system("clangd --version")
+		if clangd_version:match("espressif") then
+			-- return the absolute path to clangd
+			return vim.fn.exepath("clangd")
+		end
+	end
+
 	local home = vim.env.HOME or vim.fn.expand("~")
 	local base = home .. "/.espressif/tools/esp-clang"
 	local scandir = vim.uv.fs_scandir(base)


### PR DESCRIPTION
This helps, because currently this plugin only works, if a user installed the esp32 clangd into a subfolder of their home directory. On NixOS for example, I installed esp32-idf together with esp32 clangd using [this guide](https://nixos.wiki/wiki/ESP-IDF), which means that my `clangd` is installed into a deviating path:

```bash
> which clangd
/nix/store/s3c5vls06rx0bz4idx36zj8ygw4gna84-esp-clang-esp-idf-v5.3.1/bin/clangd
```