### PR TITLE
add: conditionally load this plugin, if an `sdkconfig` file has been found

### DIFF
--- a/lazy.lua
+++ b/lazy.lua
@@ -7,6 +7,9 @@ return {
 	opts = {
 		build_dir = "build.clang",
 	},
+	cond = function()
+		return vim.fn.filereadable(vim.fn.expand("sdkconfig"))
+	end,
 	config = function(_, opts)
 		require("esp32").setup(opts)
 	end,


### PR DESCRIPTION
I assume that esp32 projects (which are created using esp-idf) always have an sdkconfig file. This file usually stores information about what services (like bluetooth, ...) are enabled or what settings are configured.
We may only use load this plugin, if we identify the current directory as an esp32 project.