### PR TITLE
add: keyboard shortcuts to build and a key-group for all ESP32 commands

### DIFF
--- a/lazy.lua
+++ b/lazy.lua
@@ -11,6 +11,14 @@ return {
 		require("esp32").setup(opts)
 	end,
 	keys = {
+		{ "<leader>R", desc = "ESP32" },
+		{
+			"<leader>Rb",
+			function()
+				require("esp32").build()
+			end,
+			desc = "ESP32: Build",
+		},
 		{
 			"<leader>RM",
 			function()

--- a/lua/esp32/init.lua
+++ b/lua/esp32/init.lua
@@ -93,6 +93,17 @@ function M.command(cmd, port)
 	})
 end
 
+--- Run idf.py build
+function M.build()
+	local build_dir = M.options.build_dir
+	M.command("build")
+end
+
+-- Setup build command for Neovim
+vim.api.nvim_create_user_command("ESPBuild", function()
+	M.build()
+end, {})
+
 --- Create Snacks picker for port and run idf.py command
 function M.pick(cmd)
 	Snacks.picker.pick({


### PR DESCRIPTION
This pull request introduces new key mappings for the ESP32 plugin in `lazy.lua`. These mappings enhance user interaction by providing shortcuts for building ESP32 projects.

Key mapping additions:

* Added a key mapping for `<leader>R` with the description "ESP32" to serve as a general category for ESP32-related commands.
* Introduced a new key mapping for `<leader>Rb` to trigger the `require("esp32").build()` function, with the description "ESP32: Build".