### PR TITLE
add: set target implementation via snacks picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ ESP32 commands open in a floating terminal, which automatically closes when the 
 opts = {
   build_dir = "build.clang", -- directory for CMake builds (must match your clangd compile_commands.json)
   clangd_args = {}, -- optional extra clangd arguments
-  idf_cmd = nil, -- optional idf.py command override
+  idf_cmd = nil, -- optional idf.py executable or argv override, e.g. { "mise", "exec", "--", "idf.py" }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The packaged default keymaps are:
 - `<leader>RC`: clean
 - `<leader>Rr`: reconfigure
 - `<leader>Ri`: project info
+- `<leader>Rt`: set target
 
 ESP32 commands open in a floating terminal, which automatically closes when the command is done. For long-running commands like `monitor` and `menuconfig`, the terminal stays open until you close it:
 
@@ -169,6 +170,7 @@ opts = {
 | `:ESPReconfigure` | Runs ESP-IDF reconfigure with `-B build.clang -D IDF_TOOLCHAIN=clang`                       |
 | `:ESPInfo`        | Shows ESP32 project setup info                                                              |
 | `:ESPBuild`       | Runs a build of the project                                                                 |
+| `:ESPSetTarget`   | Pick a supported chip target and run `idf.py set-target`                                    |
 | `pick`            | Pick a serial port and run a command on it. Remembers the selected port for later commands. |
 | `command`         | Run a command, reusing the last selected port when available.                               |
 

--- a/lazy.lua
+++ b/lazy.lua
@@ -72,5 +72,6 @@ return {
     },
     { "<leader>Rr", ":ESPReconfigure<CR>", desc = "ESP32: Reconfigure project" },
     { "<leader>Ri", ":ESPInfo<CR>",        desc = "ESP32: Project Info" },
+    { "<leader>Rt", ":ESPSetTarget<CR>",   desc = "ESP32: Set Target" },
   },
 }

--- a/lua/esp32/init.lua
+++ b/lua/esp32/init.lua
@@ -182,14 +182,18 @@ function M.find_esp_clangd()
   return nil
 end
 
---- Resolve a command prefix that can run idf.py
-function M.resolve_idf_cmd()
+--- Resolve argv that can run idf.py without involving a shell
+function M.resolve_idf_argv()
+  if type(M.options.idf_cmd) == "table" and #M.options.idf_cmd > 0 then
+    return vim.deepcopy(M.options.idf_cmd)
+  end
+
   if type(M.options.idf_cmd) == "string" and M.options.idf_cmd ~= "" then
-    return M.options.idf_cmd
+    return { M.options.idf_cmd }
   end
 
   if executable_path("idf.py") then
-    return "idf.py"
+    return { "idf.py" }
   end
 
   if vim.env.IDF_PATH then
@@ -198,13 +202,28 @@ function M.resolve_idf_cmd()
       if vim.env.IDF_PYTHON_ENV_PATH then
         local venv_python = find_venv_python(vim.env.IDF_PYTHON_ENV_PATH)
         if venv_python then
-          return shellescape(venv_python) .. " " .. shellescape(idf_py)
+          return { venv_python, idf_py }
         end
       end
     end
   end
 
-  return "idf.py"
+  return { "idf.py" }
+end
+
+--- Escape argv as a command line for terminal-backed commands
+function M.resolve_idf_cmd()
+  local argv = M.resolve_idf_argv()
+  local escaped = {}
+
+  for _, arg in ipairs(argv) do
+    -- Keep ordinary command names and paths readable. Anything containing
+    -- whitespace or shell syntax must stay one argument in the terminal.
+    local unsafe = tostring(arg):gsub("[%w%._/%-]", ""):gsub(":", ""):gsub("\\", "")
+    table.insert(escaped, #argv == 1 and unsafe == "" and tostring(arg) or shellescape(arg))
+  end
+
+  return table.concat(escaped, " ")
 end
 
 --- Root markers of an ESP-IDF project, most specific first
@@ -253,7 +272,7 @@ end
 ---
 --- The terminal inherits Neovim's working directory, which is not necessarily
 --- the project, so point idf.py at the resolved root with -C when there is one.
-function M.make_idf_command(cmd, port)
+function M.make_idf_command(cmd, port, opts)
   local root = M.project_root()
   local full_cmd = M.resolve_idf_cmd()
 
@@ -263,12 +282,32 @@ function M.make_idf_command(cmd, port)
 
   full_cmd = full_cmd .. " -B " .. shellescape(build_dir_for(root))
 
-  local selected_port = port or M.state.last_port
+  local selected_port = not (opts and opts.include_port == false) and (port or M.state.last_port)
   if selected_port then
     full_cmd = full_cmd .. " -p " .. shellescape(selected_port)
   end
 
   return full_cmd .. " " .. cmd
+end
+
+--- Create idf.py argv for shell-independent process execution
+function M.make_idf_argv(args, port, opts)
+  local root = M.project_root()
+  local argv = M.resolve_idf_argv()
+
+  if root then
+    vim.list_extend(argv, { "-C", root })
+  end
+
+  vim.list_extend(argv, { "-B", build_dir_for(root) })
+
+  local selected_port = not (opts and opts.include_port == false) and (port or M.state.last_port)
+  if selected_port then
+    vim.list_extend(argv, { "-p", selected_port })
+  end
+
+  vim.list_extend(argv, args or {})
+  return argv
 end
 
 --- Build systems prefix the real compiler with these, so skip past them
@@ -523,10 +562,8 @@ end, {})
 function M.parse_targets(output)
   local items = {}
 
-  -- The command runs through 'shell', whose startup files print to stdout even
-  -- when non-interactive, so the output is not idf.py's alone. Only keep lines
-  -- that are a bare target name: anything else would become a picker entry
-  -- and, via confirm(), reach the shell unescaped.
+  -- Only keep bare target names from the external command. Anything else would
+  -- become a picker entry and, via confirm(), reach a terminal shell.
   for line in (output or ""):gmatch("[^\r\n]+") do
     local target = line:match("^%s*(esp%w+)%s*$")
     if target then
@@ -547,9 +584,10 @@ end
 --- noticeable, so this runs in the background and hands the parsed targets (or
 --- nil) to on_targets on the main loop.
 function M.get_targets(on_targets)
-  local cmd = M.resolve_idf_cmd() .. " --list-targets"
+  local cmd = M.resolve_idf_argv()
+  table.insert(cmd, "--list-targets")
 
-  vim.system({ vim.o.shell, vim.o.shellcmdflag, cmd }, { text = true }, function(result)
+  vim.system(cmd, { text = true }, function(result)
     -- idf.py reports environment problems on stderr; only stdout can hold
     -- targets.
     local parsed = M.parse_targets(result.stdout)
@@ -586,7 +624,7 @@ local function open_target_picker()
       if not item then
         return
       end
-      M.command("set-target " .. item.text)
+      M.change_target(item.text)
     end,
   })
 end
@@ -645,14 +683,11 @@ function M.pick(cmd)
   })
 end
 
---- Finish an idf.py reconfigure after its terminal exits
----
---- clangd only reads --compile-commands-dir at startup, so a regenerated build
---- directory does not reach a running server. Restart it once idf.py succeeds.
-function M.complete_reconfigure(root, status, terminal)
+--- Finish an idf.py operation that replaces the clang compile database
+local function complete_project_change(root, status, terminal, failure_label, success_message)
   if status ~= 0 then
     vim.notify(
-      "[ESP32] Reconfigure failed with exit code " .. tostring(status) .. ".\nCheck the terminal output.",
+      "[ESP32] " .. failure_label .. " failed with exit code " .. tostring(status) .. ".\nCheck the terminal output.",
       vim.log.levels.ERROR
     )
     return false
@@ -664,8 +699,64 @@ function M.complete_reconfigure(root, status, terminal)
   vim.cmd.checktime()
 
   if M.restart_clangd(root) then
-    vim.notify("[ESP32] Reconfigured, restarting clangd.", vim.log.levels.INFO)
+    vim.notify("[ESP32] " .. success_message .. ", restarting clangd.", vim.log.levels.INFO)
   end
+
+  return true
+end
+
+--- Finish an idf.py reconfigure after its terminal exits
+---
+--- clangd only reads --compile-commands-dir at startup, so a regenerated build
+--- directory does not reach a running server. Restart it once idf.py succeeds.
+function M.complete_reconfigure(root, status, terminal)
+  return complete_project_change(root, status, terminal, "Reconfigure", "Reconfigured")
+end
+
+--- Finish an idf.py set-target after its terminal exits
+function M.complete_target_change(root, status, terminal)
+  return complete_project_change(root, status, terminal, "Set target", "Target changed")
+end
+
+--- Change the project target while keeping a clang compile database
+function M.change_target(target)
+  if type(target) ~= "string" or not target:match("^esp%w+$") then
+    vim.notify("[ESP32] Invalid target.", vim.log.levels.ERROR)
+    return false
+  end
+
+  local Snacks = get_snacks()
+  local root = M.project_root()
+
+  -- set-target clears and regenerates the build directory, so let the new
+  -- clangd client check it again.
+  checked_roots = {}
+
+  local terminal = Snacks.terminal.open(
+    M.make_idf_argv({ "-D", "IDF_TOOLCHAIN=clang", "set-target", target }, nil, { include_port = false }),
+    {
+      auto_close = false,
+      win = {
+        width = 0.5,
+        height = 0.4,
+        title = "ESP-IDF Set Target",
+        title_pos = "center",
+      },
+    }
+  )
+
+  local bufnr = type(terminal) == "table" and terminal.buf
+  if not bufnr then
+    return false
+  end
+
+  vim.api.nvim_create_autocmd("TermClose", {
+    buffer = bufnr,
+    once = true,
+    callback = function()
+      M.complete_target_change(root, vim.v.event.status, terminal)
+    end,
+  })
 
   return true
 end

--- a/lua/esp32/init.lua
+++ b/lua/esp32/init.lua
@@ -270,9 +270,10 @@ end, {})
 function M.parse_targets(output)
   local items = {}
 
-  -- idf.py prints more than the target list on stdout, so only keep lines that
-  -- are a bare target name. Anything else would become a picker entry and, via
-  -- confirm(), reach the shell unescaped.
+  -- The command runs through 'shell', whose startup files print to stdout even
+  -- when non-interactive, so the output is not idf.py's alone. Only keep lines
+  -- that are a bare target name: anything else would become a picker entry
+  -- and, via confirm(), reach the shell unescaped.
   for line in (output or ""):gmatch("[^\r\n]+") do
     local target = line:match("^%s*(esp%w+)%s*$")
     if target then

--- a/lua/esp32/init.lua
+++ b/lua/esp32/init.lua
@@ -269,6 +269,10 @@ end, {})
 function M.get_targets()
   local cmd =  M.make_idf_command("--list-targets");
   local str = vim.fn.system(cmd);
+  -- check if we found what we're looking for
+  if not str:match("esp32") then
+    return
+  end
   local items = {}
   for line in str:gmatch("[^\r\n]+") do
     table.insert(items, { text = line })
@@ -279,7 +283,12 @@ end
 function M.set_target()
   if not targets then
     targets = M.get_targets()
+    if not targets then
+      vim.notify("[ESP32] No targets found.", vim.log.levels.WARN);
+      return
+    end
   end
+
   local Snacks = get_snacks()
   Snacks.picker.pick({
     ui_select = true,
@@ -444,6 +453,10 @@ end, {})
 
 vim.api.nvim_create_user_command("ESPInfo", function()
   M.info()
+end, {})
+
+vim.api.nvim_create_user_command("ESPSetTarget", function()
+  M.set_target()
 end, {})
 
 return M

--- a/lua/esp32/init.lua
+++ b/lua/esp32/init.lua
@@ -267,12 +267,14 @@ vim.api.nvim_create_user_command("ESPBuild", function()
 end, {})
 
 function M.get_targets()
+  -- get targets from idf.py
   local cmd =  M.make_idf_command("--list-targets");
   local str = vim.fn.system(cmd);
   -- check if we found what we're looking for
   if not str:match("esp32") then
     return
   end
+
   local items = {}
   for line in str:gmatch("[^\r\n]+") do
     table.insert(items, { text = line })
@@ -281,6 +283,7 @@ function M.get_targets()
 end
 
 function M.set_target()
+  -- targets is global so we dont have to check it every time.
   if not targets then
     targets = M.get_targets()
     if not targets then
@@ -292,7 +295,6 @@ function M.set_target()
   local Snacks = get_snacks()
   Snacks.picker.pick({
     ui_select = true,
-    -- focus = "list",
     items = targets,
     layout = {
       layout = {
@@ -303,7 +305,6 @@ function M.set_target()
           box = "vertical",
           border = "single",
           title = "Select ESP32 target",
-          -- title = "IDF targets",
           { win = "input", height = 1,     border = "bottom" },
           { win = "list",  border = "none" },
         },

--- a/lua/esp32/init.lua
+++ b/lua/esp32/init.lua
@@ -266,28 +266,42 @@ vim.api.nvim_create_user_command("ESPBuild", function()
   M.build()
 end, {})
 
-function M.get_targets()
-  -- get targets from idf.py
-  local cmd =  M.make_idf_command("--list-targets");
-  local str = vim.fn.system(cmd);
-  -- check if we found what we're looking for
-  if not str:match("esp32") then
-    return
+--- Extract target names from `idf.py --list-targets` output
+function M.parse_targets(output)
+  local items = {}
+
+  -- idf.py checks its environment before parsing arguments and reports
+  -- problems on stderr, which vim.fn.system() merges into the output. Only
+  -- keep lines that are a bare target name so warnings never reach the picker
+  -- or, via confirm(), the shell.
+  for line in (output or ""):gmatch("[^\r\n]+") do
+    local target = line:match("^%s*(esp%w+)%s*$")
+    if target then
+      table.insert(items, { text = target })
+    end
   end
 
-  local items = {}
-  for line in str:gmatch("[^\r\n]+") do
-    table.insert(items, { text = line })
+  if #items == 0 then
+    return nil
   end
+
   return items
 end
 
+--- List the targets supported by the installed ESP-IDF
+function M.get_targets()
+  local cmd = M.resolve_idf_cmd() .. " --list-targets"
+  return M.parse_targets(vim.fn.system(cmd))
+end
+
+--- Pick a target and run idf.py set-target
 function M.set_target()
-  -- targets is global so we dont have to check it every time.
+  -- Cached for the session: the target list only changes with the ESP-IDF
+  -- install, and querying it starts a full idf.py.
   if not targets then
     targets = M.get_targets()
     if not targets then
-      vim.notify("[ESP32] No targets found.", vim.log.levels.WARN);
+      vim.notify("[ESP32] No targets found.", vim.log.levels.WARN)
       return
     end
   end

--- a/lua/esp32/init.lua
+++ b/lua/esp32/init.lua
@@ -8,6 +8,8 @@ local defaults = {
   idf_cmd = nil,
 }
 
+local targets
+
 M.options = vim.deepcopy(defaults)
 M.state = {
   last_port = nil,
@@ -263,6 +265,53 @@ end
 vim.api.nvim_create_user_command("ESPBuild", function()
   M.build()
 end, {})
+
+function M.get_targets()
+  local cmd =  M.make_idf_command("--list-targets");
+  local str = vim.fn.system(cmd);
+  local items = {}
+  for line in str:gmatch("[^\r\n]+") do
+    table.insert(items, { text = line })
+  end
+  return items
+end
+
+function M.set_target()
+  if not targets then
+    targets = M.get_targets()
+  end
+  local Snacks = get_snacks()
+  Snacks.picker.pick({
+    ui_select = true,
+    -- focus = "list",
+    items = targets,
+    layout = {
+      layout = {
+        box = "horizontal",
+        width = 0.2,
+        height = 0.3,
+        {
+          box = "vertical",
+          border = "single",
+          title = "Select ESP32 target",
+          -- title = "IDF targets",
+          { win = "input", height = 1,     border = "bottom" },
+          { win = "list",  border = "none" },
+        },
+      },
+    },
+    format = function(item)
+      return { { item.text } }
+    end,
+    confirm = function(picker, item)
+      picker:close()
+      if not item then
+        return
+      end
+      M.command("set-target " .. item.text)
+    end,
+  })
+end
 
 --- Create Snacks picker for port and run idf.py command
 function M.pick(cmd)

--- a/lua/esp32/init.lua
+++ b/lua/esp32/init.lua
@@ -270,10 +270,9 @@ end, {})
 function M.parse_targets(output)
   local items = {}
 
-  -- idf.py checks its environment before parsing arguments and reports
-  -- problems on stderr, which vim.fn.system() merges into the output. Only
-  -- keep lines that are a bare target name so warnings never reach the picker
-  -- or, via confirm(), the shell.
+  -- idf.py prints more than the target list on stdout, so only keep lines that
+  -- are a bare target name. Anything else would become a picker entry and, via
+  -- confirm(), reach the shell unescaped.
   for line in (output or ""):gmatch("[^\r\n]+") do
     local target = line:match("^%s*(esp%w+)%s*$")
     if target then
@@ -289,23 +288,24 @@ function M.parse_targets(output)
 end
 
 --- List the targets supported by the installed ESP-IDF
-function M.get_targets()
+---
+--- idf.py checks its environment on every run, which takes long enough to be
+--- noticeable, so this runs in the background and hands the parsed targets (or
+--- nil) to on_targets on the main loop.
+function M.get_targets(on_targets)
   local cmd = M.resolve_idf_cmd() .. " --list-targets"
-  return M.parse_targets(vim.fn.system(cmd))
+
+  vim.system({ vim.o.shell, vim.o.shellcmdflag, cmd }, { text = true }, function(result)
+    -- idf.py reports environment problems on stderr; only stdout can hold
+    -- targets.
+    local parsed = M.parse_targets(result.stdout)
+    vim.schedule(function()
+      on_targets(parsed)
+    end)
+  end)
 end
 
---- Pick a target and run idf.py set-target
-function M.set_target()
-  -- Cached for the session: the target list only changes with the ESP-IDF
-  -- install, and querying it starts a full idf.py.
-  if not targets then
-    targets = M.get_targets()
-    if not targets then
-      vim.notify("[ESP32] No targets found.", vim.log.levels.WARN)
-      return
-    end
-  end
-
+local function open_target_picker()
   local Snacks = get_snacks()
   Snacks.picker.pick({
     ui_select = true,
@@ -335,6 +335,26 @@ function M.set_target()
       M.command("set-target " .. item.text)
     end,
   })
+end
+
+--- Pick a target and run idf.py set-target
+function M.set_target()
+  -- Cached for the session: the target list only changes with the ESP-IDF
+  -- install, and querying it starts a full idf.py.
+  if targets then
+    open_target_picker()
+    return
+  end
+
+  M.get_targets(function(found)
+    if not found then
+      vim.notify("[ESP32] No targets found.", vim.log.levels.WARN)
+      return
+    end
+
+    targets = found
+    open_target_picker()
+  end)
 end
 
 --- Create Snacks picker for port and run idf.py command

--- a/tests/esp32_spec.lua
+++ b/tests/esp32_spec.lua
@@ -718,10 +718,10 @@ T["parse_targets() keeps target names and drops idf.py diagnostics"] = function(
   local esp32 = load_module()
   reset_plugin_state(esp32)
 
-  -- idf.py prints more than the target list on stdout, and stderr can be
-  -- folded in by anything that captures both streams.
+  -- Shell startup files prepend to stdout, and stderr can be folded in by
+  -- anything that captures both streams.
   local targets = esp32.parse_targets(table.concat({
-    "Running: idf.py --list-targets",
+    "nvm: version 22 is already in use",
     "WARNING: The IDF_PYTHON_ENV_PATH is missing in environmental variables!",
     "Setting IDF_PATH environment variable: /home/test/esp32-project/esp-idf",
     "esp32",

--- a/tests/esp32_spec.lua
+++ b/tests/esp32_spec.lua
@@ -13,10 +13,12 @@ local original_uv = {}
 local original_system = vim.system
 local original_schedule = vim.schedule
 local notifications = {}
+local system_calls = {}
 
 --- Stub vim.system() with a fixed result for the spawned command
 local function set_system_result(result)
-  vim.system = function(_, _, on_exit)
+  vim.system = function(cmd, opts, on_exit)
+    table.insert(system_calls, { cmd = cmd, opts = opts })
     on_exit(result)
     return { wait = function() return result end }
   end
@@ -115,6 +117,7 @@ end
 local function prepare_case()
   reset_module()
   notifications = {}
+  system_calls = {}
   vim.notify = function(message, level)
     table.insert(notifications, { message = message, level = level })
   end
@@ -364,13 +367,59 @@ T["resolve_idf_cmd() uses the Scripts python interpreter on Windows"] = function
   local esp32 = load_module()
   reset_plugin_state(esp32)
   local cmd = esp32.resolve_idf_cmd()
+  local argv = esp32.resolve_idf_argv()
   vim.fn.has = previous_has
 
+  expect.equality(argv, {
+    "C:/Espressif/python_env/idf6.0_py3.11_env/Scripts/python.exe",
+    "C:/Espressif/frameworks/esp-idf-v6.0.2/tools/idf.py",
+  })
   expect.equality(
     cmd,
     "'C:/Espressif/python_env/idf6.0_py3.11_env/Scripts/python.exe' "
       .. "'C:/Espressif/frameworks/esp-idf-v6.0.2/tools/idf.py'"
   )
+end
+
+T["get_targets() invokes the Windows EIM Python command without a shell"] = function()
+  prepare_case()
+  local previous_has = vim.fn.has
+  vim.fn.has = function(feature)
+    if feature == "win32" then
+      return 1
+    end
+    return previous_has(feature)
+  end
+  vim.env.IDF_PATH = "C:/Program Files/Espressif/frameworks/esp-idf-v6.0.2"
+  vim.env.IDF_PYTHON_ENV_PATH = "C:/Program Files/Espressif/python_env/idf6.0_py3.11_env"
+
+  vim.fn.executable = function(path)
+    return path == "C:/Program Files/Espressif/python_env/idf6.0_py3.11_env/Scripts/python.exe" and 1 or 0
+  end
+  vim.fn.filereadable = function(path)
+    return path == "C:/Program Files/Espressif/frameworks/esp-idf-v6.0.2/tools/idf.py" and 1 or 0
+  end
+
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+  set_system_result({ code = 0, stdout = "esp32\n", stderr = "" })
+
+  local found
+  run_scheduled(function()
+    esp32.get_targets(function(items)
+      found = items
+    end)
+  end)
+
+  vim.fn.has = previous_has
+
+  expect.equality(system_calls[1].cmd, {
+    "C:/Program Files/Espressif/python_env/idf6.0_py3.11_env/Scripts/python.exe",
+    "C:/Program Files/Espressif/frameworks/esp-idf-v6.0.2/tools/idf.py",
+    "--list-targets",
+  })
+  expect.equality(system_calls[1].opts, { text = true })
+  expect.equality(found, { { text = "esp32" } })
 end
 
 T["lsp_config() uses build_dir, root markers, and appends clangd_args"] = function()
@@ -901,6 +950,19 @@ T["make_idf_command() respects a configured idf_cmd"] = function()
   )
 end
 
+T["resolve_idf_argv() supports paths with spaces and argv overrides"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  esp32.options.idf_cmd = "C:/Program Files/Espressif/idf.py"
+  expect.equality(esp32.resolve_idf_argv(), { "C:/Program Files/Espressif/idf.py" })
+  expect.equality(esp32.resolve_idf_cmd(), "'C:/Program Files/Espressif/idf.py'")
+
+  esp32.options.idf_cmd = { "mise", "exec", "--", "idf.py" }
+  expect.equality(esp32.resolve_idf_argv(), { "mise", "exec", "--", "idf.py" })
+end
+
 T["resolve_idf_cmd() ignores an empty idf_cmd override"] = function()
   prepare_case()
   vim.fn.executable = function(path)
@@ -1134,8 +1196,7 @@ T["parse_targets() keeps target names and drops idf.py diagnostics"] = function(
   local esp32 = load_module()
   reset_plugin_state(esp32)
 
-  -- Shell startup files prepend to stdout, and stderr can be folded in by
-  -- anything that captures both streams.
+  -- Only bare target names from the external command may reach the picker.
   local targets = esp32.parse_targets(table.concat({
     "nvm: version 22 is already in use",
     "WARNING: The IDF_PYTHON_ENV_PATH is missing in environmental variables!",
@@ -1164,15 +1225,11 @@ end
 T["set_target() runs set-target for the picked target"] = function()
   prepare_case()
   local picker_spec
-  local calls = {}
+  local selected_target
   local esp32 = load_module({
     terminal = {
-      open = function(cmd, opts)
-        table.insert(calls, { method = "open", cmd = cmd, opts = opts })
-      end,
-      toggle = function(cmd, opts)
-        table.insert(calls, { method = "toggle", cmd = cmd, opts = opts })
-      end,
+      open = function() end,
+      toggle = function() end,
     },
     picker = {
       pick = function(spec)
@@ -1187,6 +1244,9 @@ T["set_target() runs set-target for the picked target"] = function()
   })
 
   reset_plugin_state(esp32)
+  esp32.change_target = function(target)
+    selected_target = target
+  end
   set_system_result({ code = 0, stdout = "esp32\nesp32s3\n", stderr = "" })
 
   run_scheduled(function()
@@ -1197,8 +1257,97 @@ T["set_target() runs set-target for the picked target"] = function()
 
   picker_spec.confirm({ close = function() end }, { text = "esp32s3" })
 
-  expect.equality(calls[1].method, "open")
-  expect.equality(calls[1].cmd, "idf.py -B 'build.clang' set-target esp32s3")
+  expect.equality(system_calls[1].cmd, { "idf.py", "--list-targets" })
+  expect.equality(system_calls[1].opts, { text = true })
+  expect.equality(selected_target, "esp32s3")
+end
+
+T["change_target() preserves the clang toolchain and registers its completion handler"] = function()
+  prepare_case()
+  local opened
+  local autocmd_spec
+  local terminal = { buf = 123 }
+  local esp32 = load_module({
+    terminal = {
+      open = function(cmd, opts)
+        opened = { cmd = cmd, opts = opts }
+        return terminal
+      end,
+      toggle = function() end,
+    },
+    picker = {
+      pick = function() end,
+      util = {
+        align = function(value)
+          return value
+        end,
+      },
+    },
+  })
+  reset_plugin_state(esp32)
+  esp32.state.last_port = "/dev/ttyUSB9"
+  esp32.project_root = function()
+    return "/project/blink"
+  end
+
+  local previous_create_autocmd = vim.api.nvim_create_autocmd
+  vim.api.nvim_create_autocmd = function(event, spec)
+    autocmd_spec = vim.tbl_extend("force", { event = event }, spec)
+    return 1
+  end
+
+  local started = esp32.change_target("esp32s3")
+
+  vim.api.nvim_create_autocmd = previous_create_autocmd
+
+  expect.equality(started, true)
+  expect.equality(opened.cmd, {
+    "idf.py",
+    "-C",
+    "/project/blink",
+    "-B",
+    "/project/blink/build.clang",
+    "-D",
+    "IDF_TOOLCHAIN=clang",
+    "set-target",
+    "esp32s3",
+  })
+  expect.equality(opened.opts.auto_close, false)
+  expect.equality(opened.opts.win.title, "ESP-IDF Set Target")
+  expect.equality(vim.tbl_contains(opened.cmd, "/dev/ttyUSB9"), false)
+  expect.equality(autocmd_spec.event, "TermClose")
+  expect.equality(autocmd_spec.buffer, 123)
+  expect.equality(autocmd_spec.once, true)
+  expect.equality(type(autocmd_spec.callback), "function")
+end
+
+T["complete_target_change() closes the terminal and restarts project clangd"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  local restarted_root
+  local closed = false
+  esp32.restart_clangd = function(root)
+    restarted_root = root
+    return true
+  end
+
+  local completed = esp32.complete_target_change("/project/blink", 0, {
+    close = function()
+      closed = true
+    end,
+  })
+
+  expect.equality(completed, true)
+  expect.equality(closed, true)
+  expect.equality(restarted_root, "/project/blink")
+  expect.equality(notifications, {
+    {
+      message = "[ESP32] Target changed, restarting clangd.",
+      level = vim.log.levels.INFO,
+    },
+  })
 end
 
 T["set_target() warns and skips the picker when no targets are found"] = function()

--- a/tests/esp32_spec.lua
+++ b/tests/esp32_spec.lua
@@ -20,6 +20,7 @@ local function reset_module()
   restore_command("ESPBuild")
   restore_command("ESPReconfigure")
   restore_command("ESPInfo")
+  restore_command("ESPSetTarget")
   package.loaded["esp32"] = nil
   package.loaded["snacks"] = nil
 end
@@ -611,6 +612,7 @@ T["module load registers user commands"] = function()
   expect_truthy(commands.ESPBuild ~= nil)
   expect_truthy(commands.ESPReconfigure ~= nil)
   expect_truthy(commands.ESPInfo ~= nil)
+  expect_truthy(commands.ESPSetTarget ~= nil)
 end
 
 T["command() reuses the last selected port and toggles monitor sessions"] = function()
@@ -678,6 +680,108 @@ T["pick() stores the selected port and runs the command with it"] = function()
   expect.equality(esp32.state.last_port, "/dev/ttyACM0")
   expect.equality(calls[1].method, "toggle")
   expect.equality(calls[1].cmd, "idf.py -B 'build.clang' -p '/dev/ttyACM0' monitor")
+end
+
+T["parse_targets() keeps target names and drops idf.py diagnostics"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  -- idf.py reports environment problems on stderr, which vim.fn.system()
+  -- merges into the output it returns.
+  local targets = esp32.parse_targets(table.concat({
+    "WARNING: The IDF_PYTHON_ENV_PATH is missing in environmental variables!",
+    "Setting IDF_PATH environment variable: /home/test/esp32-project/esp-idf",
+    "esp32",
+    "esp32s3",
+    "esp32c61",
+  }, "\n"))
+
+  expect.equality(#targets, 3)
+  expect.equality(targets[1].text, "esp32")
+  expect.equality(targets[2].text, "esp32s3")
+  expect.equality(targets[3].text, "esp32c61")
+end
+
+T["parse_targets() returns nil when no target survives"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  expect.equality(esp32.parse_targets(""), nil)
+  -- A failure that merely mentions a target name is not a target list.
+  expect.equality(esp32.parse_targets("ERROR: unsupported target esp32c6 in sdkconfig"), nil)
+end
+
+T["set_target() runs set-target for the picked target"] = function()
+  prepare_case()
+  local picker_spec
+  local calls = {}
+  local esp32 = load_module({
+    terminal = {
+      open = function(cmd, opts)
+        table.insert(calls, { method = "open", cmd = cmd, opts = opts })
+      end,
+      toggle = function(cmd, opts)
+        table.insert(calls, { method = "toggle", cmd = cmd, opts = opts })
+      end,
+    },
+    picker = {
+      pick = function(spec)
+        picker_spec = spec
+      end,
+      util = {
+        align = function(value)
+          return value
+        end,
+      },
+    },
+  })
+
+  reset_plugin_state(esp32)
+  vim.fn.system = function()
+    return "esp32\nesp32s3\n"
+  end
+
+  esp32.set_target()
+  expect.equality(#picker_spec.items, 2)
+
+  picker_spec.confirm({ close = function() end }, { text = "esp32s3" })
+
+  expect.equality(calls[1].method, "open")
+  expect.equality(calls[1].cmd, "idf.py -B 'build.clang' set-target esp32s3")
+end
+
+T["set_target() warns and skips the picker when no targets are found"] = function()
+  prepare_case()
+  local picked = false
+  local esp32 = load_module({
+    terminal = {
+      open = function() end,
+      toggle = function() end,
+    },
+    picker = {
+      pick = function()
+        picked = true
+      end,
+      util = {
+        align = function(value)
+          return value
+        end,
+      },
+    },
+  })
+
+  reset_plugin_state(esp32)
+  vim.fn.system = function()
+    return "idf.py: command not found\n"
+  end
+
+  esp32.set_target()
+
+  expect.equality(picked, false)
+  expect.equality(#notifications, 1)
+  expect_truthy(notifications[1].message:match("No targets found"))
 end
 
 T["lazy.lua packaged spec exposes expected defaults"] = function()

--- a/tests/esp32_spec.lua
+++ b/tests/esp32_spec.lua
@@ -10,7 +10,35 @@ local original_idf_python_env_path = vim.env.IDF_PYTHON_ENV_PATH
 local original_idf_tools_path = vim.env.IDF_TOOLS_PATH
 local original_fn = {}
 local original_uv = {}
+local original_system = vim.system
+local original_schedule = vim.schedule
 local notifications = {}
+
+--- Stub vim.system() with a fixed result for the spawned command
+local function set_system_result(result)
+  vim.system = function(_, _, on_exit)
+    on_exit(result)
+    return { wait = function() return result end }
+  end
+end
+
+--- Run fn with vim.schedule() applied inline.
+---
+--- The async target lookup defers its callback off the libuv thread, and
+--- driving the real event loop from inside a case stops MiniTest from running
+--- the remaining ones, so collapse the deferral instead of waiting on it.
+local function run_scheduled(fn)
+  vim.schedule = function(callback)
+    callback()
+  end
+
+  local ok, err = pcall(fn)
+  vim.schedule = original_schedule
+
+  if not ok then
+    error(err)
+  end
+end
 
 local function restore_command(name)
   pcall(vim.api.nvim_del_user_command, name)
@@ -110,6 +138,7 @@ local function prepare_case()
   vim.fn.expand = function()
     return "/home/test"
   end
+  set_system_result({ code = 0, stdout = "", stderr = "" })
   set_scandir({})
 end
 
@@ -139,6 +168,8 @@ T.hooks = {
     vim.fn.expand = original_fn.expand
     vim.uv.fs_scandir = original_uv.fs_scandir
     vim.uv.fs_scandir_next = original_uv.fs_scandir_next
+    vim.system = original_system
+    vim.schedule = original_schedule
   end,
 }
 
@@ -687,9 +718,10 @@ T["parse_targets() keeps target names and drops idf.py diagnostics"] = function(
   local esp32 = load_module()
   reset_plugin_state(esp32)
 
-  -- idf.py reports environment problems on stderr, which vim.fn.system()
-  -- merges into the output it returns.
+  -- idf.py prints more than the target list on stdout, and stderr can be
+  -- folded in by anything that captures both streams.
   local targets = esp32.parse_targets(table.concat({
+    "Running: idf.py --list-targets",
     "WARNING: The IDF_PYTHON_ENV_PATH is missing in environmental variables!",
     "Setting IDF_PATH environment variable: /home/test/esp32-project/esp-idf",
     "esp32",
@@ -739,11 +771,12 @@ T["set_target() runs set-target for the picked target"] = function()
   })
 
   reset_plugin_state(esp32)
-  vim.fn.system = function()
-    return "esp32\nesp32s3\n"
-  end
+  set_system_result({ code = 0, stdout = "esp32\nesp32s3\n", stderr = "" })
 
-  esp32.set_target()
+  run_scheduled(function()
+    esp32.set_target()
+  end)
+
   expect.equality(#picker_spec.items, 2)
 
   picker_spec.confirm({ close = function() end }, { text = "esp32s3" })
@@ -773,11 +806,16 @@ T["set_target() warns and skips the picker when no targets are found"] = functio
   })
 
   reset_plugin_state(esp32)
-  vim.fn.system = function()
-    return "idf.py: command not found\n"
-  end
+  -- idf.py keeps warnings and errors on stderr, so stdout holds no targets.
+  set_system_result({
+    code = 1,
+    stdout = "",
+    stderr = "WARNING: The IDF_PYTHON_ENV_PATH is missing in environmental variables!\n",
+  })
 
-  esp32.set_target()
+  run_scheduled(function()
+    esp32.set_target()
+  end)
 
   expect.equality(picked, false)
   expect.equality(#notifications, 1)


### PR DESCRIPTION
Added keybind `<leader>Rt` to automatically get targets from `idf.py` and do a `idf.py set-target [target]` (using the M.command(cmd) implementation)