### PR TITLE
fix: detect GCC compile databases and fix the clangd placeholder flag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        neovim:
+          - v0.11.4
+          - stable
 
     steps:
       - name: Check out repository
@@ -18,7 +23,7 @@ jobs:
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: stable
+          version: ${{ matrix.neovim }}
 
       - name: Check Neovim version
         run: nvim --version

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /tests/deps/
+nvim.log

--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ The plugin defines the user commands above automatically. When installed through
 - You must either:
   - Source an ESP-IDF environment before launching Neovim
   - Or use a project-local Nix/direnv shell to source that environment for you
+- When clangd attaches, the plugin checks the build directory of that project
+  and warns once if `compile_commands.json` is missing, or if it was generated
+  for the GCC toolchain. The latter happens when a project is built before
+  `:ESPReconfigure` has run: clangd then reports ESP-IDF's GCC flags as unknown
+  arguments and cannot find headers such as `sys/features.h`. `:ESPReconfigure`
+  regenerates the build directory with `IDF_TOOLCHAIN=clang` and clears both
+  warnings.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Version](https://img.shields.io/github/v/tag/Aietes/esp32.nvim?style=for-the-badge&label=version&sort=semver)](https://github.com/Aietes/esp32.nvim/tags)
 [![Tests](https://img.shields.io/github/actions/workflow/status/Aietes/esp32.nvim/tests.yml?branch=main&style=for-the-badge&label=tests)](https://github.com/Aietes/esp32.nvim/actions/workflows/tests.yml)
 [![Last Commit](https://img.shields.io/github/last-commit/Aietes/esp32.nvim?style=for-the-badge)](https://github.com/Aietes/esp32.nvim/commits/main)
-[![Neovim](https://img.shields.io/badge/Neovim-0.10%2B-57A143?style=for-the-badge&logo=neovim&logoColor=white)](https://neovim.io/)
+[![Neovim](https://img.shields.io/badge/Neovim-0.11%2B-57A143?style=for-the-badge&logo=neovim&logoColor=white)](https://neovim.io/)
 [![License](https://img.shields.io/github/license/Aietes/esp32.nvim?style=for-the-badge)](https://github.com/Aietes/esp32.nvim/blob/main/LICENSE)
 
 **ESP32.nvim** makes working with ESP-IDF projects in Neovim a breeze.
@@ -22,6 +22,7 @@ Uses [snacks.nvim](https://github.com/folke/snacks.nvim) for terminal and picker
 
 ## 🚀 Requirements
 
+- Neovim 0.11 or newer
 - [ESP-IDF](https://github.com/espressif/esp-idf) installed and initialized. The recommended upstream setup is now [ESP-IDF Installation Manager](https://docs.espressif.com/projects/idf-im-ui/en/latest/).
 - ESP-specific `clangd` is installed. With ESP-IDF Installation Manager, include `esp-clang` in the selected tools, or run `idf_tools.py install esp-clang` from an activated ESP-IDF shell.
 - ESP-specific `clangd` is configured via `idf.py -B build.clang -D IDF_TOOLCHAIN=clang reconfigure` (can be done via command `:ESPReconfigure`)

--- a/README.md
+++ b/README.md
@@ -184,9 +184,15 @@ The plugin defines the user commands above automatically. When installed through
   and warns once if `compile_commands.json` is missing, or if it was generated
   for the GCC toolchain. The latter happens when a project is built before
   `:ESPReconfigure` has run: clangd then reports ESP-IDF's GCC flags as unknown
-  arguments and cannot find headers such as `sys/features.h`. `:ESPReconfigure`
-  regenerates the build directory with `IDF_TOOLCHAIN=clang` and clears both
-  warnings.
+  arguments and cannot find headers such as `sys/features.h`.
+- `:ESPReconfigure` regenerates the build directory with `IDF_TOOLCHAIN=clang`
+  and then restarts clangd. The restart matters: clangd reads
+  `--compile-commands-dir` only at startup and discards it when the directory
+  does not exist yet, so a server started before the first reconfigure keeps
+  ignoring the build directory until it is started again.
+- ESP-IDF commands and the checks above act on the project root, resolved from
+  the attached clangd client or by searching upwards for `sdkconfig` /
+  `CMakeLists.txt`, so they work when Neovim was started outside the project.
 
 ---
 

--- a/lua/esp32/init.lua
+++ b/lua/esp32/init.lua
@@ -217,11 +217,54 @@ function M.make_idf_command(cmd, port)
   return full_cmd .. " " .. cmd
 end
 
---- Ensure compile_commands.json exists
+--- Identify the compiler a compile database was generated for
+---
+--- Returns "clang", "gcc", or nil when the database is missing or the compiler
+--- cannot be recognised. A database written for the GCC toolchain drives clangd
+--- into reporting unknown arguments and missing headers, because the ESP-IDF
+--- GCC flags and newlib headers have no clang equivalent.
+function M.compile_commands_toolchain()
+  local path = join_path(M.options.build_dir, "compile_commands.json")
+  if vim.fn.filereadable(path) == 0 then
+    return nil
+  end
+
+  -- The database grows with the project, so read only far enough to reach the
+  -- compiler of the first entry rather than loading the whole file.
+  local head = table.concat(vim.fn.readfile(path, "", 40), "\n")
+  local compiler = head:match('"command"%s*:%s*"([^"%s]+)')
+    or head:match('"arguments"%s*:%s*%[%s*"([^"]+)"')
+
+  if not compiler then
+    return nil
+  end
+
+  if compiler:match("%-gcc") then
+    return "gcc"
+  end
+
+  if compiler:match("clang") then
+    return "clang"
+  end
+
+  return nil
+end
+
+--- Ensure compile_commands.json exists and was generated for clang
 function M.ensure_compile_commands()
-  local path = M.options.build_dir .. "/compile_commands.json"
+  local path = join_path(M.options.build_dir, "compile_commands.json")
   if vim.fn.filereadable(path) == 0 then
     vim.notify("[ESP32] ⚠️ Missing compile_commands.json in " .. path, vim.log.levels.WARN)
+    return
+  end
+
+  if M.compile_commands_toolchain() == "gcc" then
+    vim.notify(
+      "[ESP32] ⚠️ " .. path .. " was generated for the GCC toolchain."
+        .. "\nclangd will report unknown arguments and missing headers."
+        .. "\nRun :ESPReconfigure to regenerate it with IDF_TOOLCHAIN=clang.",
+      vim.log.levels.WARN
+    )
   end
 end
 
@@ -325,7 +368,8 @@ function M.lsp_config()
     "--clang-tidy",
     "--header-insertion=iwyu",
     "--completion-style=detailed",
-    "--function-arg-placeholders",
+    -- clangd 20 rejects the bare flag and wants an explicit boolean.
+    "--function-arg-placeholders=true",
     "--fallback-style=llvm",
   }
 
@@ -360,7 +404,12 @@ function M.info()
   local build_dir = M.options.build_dir
   local path = build_dir .. "/compile_commands.json"
   if vim.fn.filereadable(path) == 1 then
-    table.insert(messages, "✓ compile_commands.json exists")
+    local toolchain = M.compile_commands_toolchain()
+    if toolchain == "gcc" then
+      table.insert(messages, "✗ compile_commands.json was generated for GCC, run :ESPReconfigure")
+    else
+      table.insert(messages, "✓ compile_commands.json exists")
+    end
   else
     table.insert(messages, "✗ compile_commands.json missing")
   end

--- a/lua/esp32/init.lua
+++ b/lua/esp32/init.lua
@@ -418,19 +418,30 @@ function M.restart_clangd(root)
 
   for _, client in ipairs(vim.lsp.get_clients({ name = "clangd" })) do
     if not root or client.root_dir == root then
-      local buffers = vim.lsp.get_buffers_by_client_id(client.id)
-      client:stop()
-      restarted = true
+      local buffers = vim.tbl_keys(client.attached_buffers or {})
+      table.sort(buffers)
 
-      -- Re-attach once the old process is gone; the FileType autocmd is what
-      -- every LSP setup hangs its clangd config off.
-      vim.defer_fn(function()
-        for _, bufnr in ipairs(buffers) do
-          if vim.api.nvim_buf_is_valid(bufnr) then
-            vim.api.nvim_exec_autocmds("FileType", { buffer = bufnr })
+      if client.config and #buffers > 0 then
+        local config = client.config
+        client:stop()
+        restarted = true
+
+        -- stop() marks the old client as stopping synchronously, so start()
+        -- cannot reuse it. The first valid buffer creates the replacement;
+        -- subsequent buffers reuse that client without replaying unrelated
+        -- FileType autocmds or relying on an arbitrary delay.
+        vim.schedule(function()
+          for _, bufnr in ipairs(buffers) do
+            if vim.api.nvim_buf_is_valid(bufnr) then
+              local client_id = vim.lsp.start(config, { bufnr = bufnr })
+              if not client_id then
+                vim.notify("[ESP32] Failed to restart clangd.", vim.log.levels.ERROR)
+                return
+              end
+            end
           end
-        end
-      end, 500)
+        end)
+      end
     end
   end
 
@@ -540,10 +551,35 @@ function M.pick(cmd)
   })
 end
 
---- Run idf.py reconfigure for build.clang
+--- Finish an idf.py reconfigure after its terminal exits
 ---
 --- clangd only reads --compile-commands-dir at startup, so a regenerated build
 --- directory does not reach a running server. Restart it once idf.py succeeds.
+function M.complete_reconfigure(root, status, terminal)
+  if status ~= 0 then
+    vim.notify(
+      "[ESP32] Reconfigure failed with exit code " .. tostring(status) .. ".\nCheck the terminal output.",
+      vim.log.levels.ERROR
+    )
+    return false
+  end
+
+  if terminal and type(terminal.close) == "function" then
+    terminal:close()
+  end
+  vim.cmd.checktime()
+
+  if M.restart_clangd(root) then
+    vim.notify("[ESP32] Reconfigured, restarting clangd.", vim.log.levels.INFO)
+  end
+
+  return true
+end
+
+--- Run idf.py reconfigure for build.clang
+---
+--- Keep the terminal alive until our TermClose handler sees the exit status.
+--- Snacks otherwise removes a successful terminal before later handlers run.
 function M.reconfigure()
   local Snacks = get_snacks()
   local root = M.project_root()
@@ -552,6 +588,7 @@ function M.reconfigure()
   checked_roots = {}
 
   local terminal = Snacks.terminal.open(M.make_idf_command("-D IDF_TOOLCHAIN=clang reconfigure"), {
+    auto_close = false,
     win = {
       width = 0.5,
       height = 0.4,
@@ -569,13 +606,7 @@ function M.reconfigure()
     buffer = bufnr,
     once = true,
     callback = function()
-      if vim.v.event.status ~= 0 then
-        return
-      end
-
-      if M.restart_clangd(root) then
-        vim.notify("[ESP32] Reconfigured, restarting clangd.", vim.log.levels.INFO)
-      end
+      M.complete_reconfigure(root, vim.v.event.status, terminal)
     end,
   })
 end

--- a/lua/esp32/init.lua
+++ b/lua/esp32/init.lua
@@ -217,14 +217,29 @@ function M.make_idf_command(cmd, port)
   return full_cmd .. " " .. cmd
 end
 
+--- Locate the compile database, resolving build_dir against a project root
+---
+--- build_dir is relative by default, and Neovim's working directory is not
+--- necessarily the project, so prefer the root clangd itself resolved against.
+local function compile_commands_path(root)
+  local dir = M.options.build_dir
+  local is_absolute = dir:match("^[/\\]") or dir:match("^%a:[/\\]")
+
+  if root and not is_absolute then
+    dir = join_path(root, dir)
+  end
+
+  return join_path(dir, "compile_commands.json")
+end
+
 --- Identify the compiler a compile database was generated for
 ---
 --- Returns "clang", "gcc", or nil when the database is missing or the compiler
 --- cannot be recognised. A database written for the GCC toolchain drives clangd
 --- into reporting unknown arguments and missing headers, because the ESP-IDF
 --- GCC flags and newlib headers have no clang equivalent.
-function M.compile_commands_toolchain()
-  local path = join_path(M.options.build_dir, "compile_commands.json")
+function M.compile_commands_toolchain(root)
+  local path = compile_commands_path(root)
   if vim.fn.filereadable(path) == 0 then
     return nil
   end
@@ -251,14 +266,14 @@ function M.compile_commands_toolchain()
 end
 
 --- Ensure compile_commands.json exists and was generated for clang
-function M.ensure_compile_commands()
-  local path = join_path(M.options.build_dir, "compile_commands.json")
+function M.ensure_compile_commands(root)
+  local path = compile_commands_path(root)
   if vim.fn.filereadable(path) == 0 then
     vim.notify("[ESP32] ⚠️ Missing compile_commands.json in " .. path, vim.log.levels.WARN)
     return
   end
 
-  if M.compile_commands_toolchain() == "gcc" then
+  if M.compile_commands_toolchain(root) == "gcc" then
     vim.notify(
       "[ESP32] ⚠️ " .. path .. " was generated for the GCC toolchain."
         .. "\nclangd will report unknown arguments and missing headers."
@@ -267,6 +282,36 @@ function M.ensure_compile_commands()
     )
   end
 end
+
+--- Projects already reported on, so one bad build dir warns once per session
+local checked_roots = {}
+
+--- Check the compile database of a project clangd just attached to
+---
+--- Hooked to LspAttach rather than to opening a buffer because that is where
+--- the resolved project root is available, and because the warnings only
+--- describe how clangd behaves.
+function M.check_attached_client(client_id)
+  local client = vim.lsp.get_client_by_id(client_id)
+  if not client or client.name ~= "clangd" then
+    return
+  end
+
+  local root = client.root_dir
+  if not root or checked_roots[root] then
+    return
+  end
+
+  checked_roots[root] = true
+  M.ensure_compile_commands(root)
+end
+
+vim.api.nvim_create_autocmd("LspAttach", {
+  group = vim.api.nvim_create_augroup("Esp32CheckCompileCommands", { clear = true }),
+  callback = function(args)
+    M.check_attached_client(args.data and args.data.client_id)
+  end,
+})
 
 --- Ensure esp-clangd exists and warn if not
 function M.ensure_clangd()
@@ -344,6 +389,8 @@ end
 --- Run idf.py reconfigure for build.clang
 function M.reconfigure()
   local Snacks = get_snacks()
+  -- The build dir is about to change, so let it be reported on again.
+  checked_roots = {}
   Snacks.terminal.open(M.make_idf_command("-D IDF_TOOLCHAIN=clang reconfigure"), {
     win = {
       width = 0.5,

--- a/lua/esp32/init.lua
+++ b/lua/esp32/init.lua
@@ -205,23 +205,33 @@ function M.resolve_idf_cmd()
   return "idf.py"
 end
 
---- Create an idf.py command line
-function M.make_idf_command(cmd, port)
-  local full_cmd = M.resolve_idf_cmd() .. " -B " .. shellescape(M.options.build_dir)
-  local selected_port = port or M.state.last_port
+--- Root markers of an ESP-IDF project, most specific first
+local root_markers = { "sdkconfig", "CMakeLists.txt" }
 
-  if selected_port then
-    full_cmd = full_cmd .. " -p " .. shellescape(selected_port)
+--- Resolve the ESP-IDF project a buffer belongs to
+---
+--- Prefers the root an attached clangd resolved, so commands act on the same
+--- project the LSP does, and falls back to searching upwards for a marker.
+--- Returns nil when nothing looks like a project, leaving callers on Neovim's
+--- working directory.
+function M.project_root(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+  for _, client in ipairs(vim.lsp.get_clients({ name = "clangd", bufnr = bufnr })) do
+    if client.root_dir then
+      return client.root_dir
+    end
   end
 
-  return full_cmd .. " " .. cmd
+  local name = vim.api.nvim_buf_get_name(bufnr)
+  return vim.fs.root(name ~= "" and name or vim.fn.getcwd(), root_markers)
 end
 
---- Locate the compile database, resolving build_dir against a project root
+--- Resolve build_dir against a project root
 ---
 --- build_dir is relative by default, and Neovim's working directory is not
---- necessarily the project, so prefer the root clangd itself resolved against.
-local function compile_commands_path(root)
+--- necessarily the project, so anything that has a root should pass it.
+local function build_dir_for(root)
   local dir = M.options.build_dir
   local is_absolute = dir:match("^[/\\]") or dir:match("^%a:[/\\]")
 
@@ -229,7 +239,119 @@ local function compile_commands_path(root)
     dir = join_path(root, dir)
   end
 
-  return join_path(dir, "compile_commands.json")
+  return dir
+end
+
+--- Locate the compile database of a project
+local function compile_commands_path(root)
+  return join_path(build_dir_for(root), "compile_commands.json")
+end
+
+--- Create an idf.py command line
+---
+--- The terminal inherits Neovim's working directory, which is not necessarily
+--- the project, so point idf.py at the resolved root with -C when there is one.
+function M.make_idf_command(cmd, port)
+  local root = M.project_root()
+  local full_cmd = M.resolve_idf_cmd()
+
+  if root then
+    full_cmd = full_cmd .. " -C " .. shellescape(root)
+  end
+
+  full_cmd = full_cmd .. " -B " .. shellescape(build_dir_for(root))
+
+  local selected_port = port or M.state.last_port
+  if selected_port then
+    full_cmd = full_cmd .. " -p " .. shellescape(selected_port)
+  end
+
+  return full_cmd .. " " .. cmd
+end
+
+--- Build systems prefix the real compiler with these, so skip past them
+local compiler_launchers = {
+  ccache = true,
+  sccache = true,
+  distcc = true,
+  icecc = true,
+  buildcache = true,
+}
+
+--- Split a command line into arguments, honouring quoted paths
+---
+--- Windows toolchain paths contain spaces often enough that splitting on
+--- whitespace alone misreads the compiler.
+local function split_command(command)
+  local args = {}
+  local index = 1
+
+  while index <= #command do
+    local char = command:sub(index, index)
+
+    if char == " " or char == "\t" then
+      index = index + 1
+    elseif char == '"' then
+      local closing = command:find('"', index + 1, true)
+      if not closing then
+        break
+      end
+      table.insert(args, command:sub(index + 1, closing - 1))
+      index = closing + 1
+    else
+      local stop = command:find("[ \t]", index) or (#command + 1)
+      table.insert(args, command:sub(index, stop - 1))
+      index = stop
+    end
+  end
+
+  return args
+end
+
+--- Reduce a compiler path to a comparable basename
+local function compiler_name(path)
+  local name = path:match("([^/\\]+)$") or path
+  return name:gsub("%.exe$", ""):lower()
+end
+
+--- Classify the compiler of a compile database entry
+---
+--- Accepts either the "command" string or the "arguments" list of an entry.
+--- Returns "clang", "gcc", or nil when the name is not recognised.
+function M.classify_compiler(command)
+  local args
+  if type(command) == "table" then
+    args = command
+  elseif type(command) == "string" and command ~= "" then
+    args = split_command(command)
+  else
+    return nil
+  end
+
+  local index = 1
+
+  -- ESP-IDF enables ccache when it is available, which puts the launcher
+  -- rather than the compiler in the first position.
+  while args[index] and compiler_launchers[compiler_name(args[index])] do
+    index = index + 1
+  end
+
+  local name = args[index] and compiler_name(args[index])
+  if not name then
+    return nil
+  end
+
+  if name:match("clang%+?%+?$") then
+    return "clang"
+  end
+
+  -- Covers xtensa-esp32-elf-gcc, riscv32-esp-elf-g++, plain gcc/g++ and the
+  -- cc/c++ aliases.
+  if name:match("g?cc$") or name:match("g?%+%+$") then
+    return "gcc"
+  end
+
+  return nil
 end
 
 --- Identify the compiler a compile database was generated for
@@ -245,31 +367,35 @@ function M.compile_commands_toolchain(root)
   end
 
   -- The database grows with the project, so read only far enough to reach the
-  -- compiler of the first entry rather than loading the whole file.
+  -- first entry rather than loading the whole file, then let the JSON decoder
+  -- deal with escaping instead of matching quotes by hand.
   local head = table.concat(vim.fn.readfile(path, "", 40), "\n")
-  local compiler = head:match('"command"%s*:%s*"([^"%s]+)')
-    or head:match('"arguments"%s*:%s*%[%s*"([^"]+)"')
-
-  if not compiler then
+  local entry = head:match("%b{}")
+  if not entry then
     return nil
   end
 
-  if compiler:match("%-gcc") then
-    return "gcc"
+  local ok, decoded = pcall(vim.json.decode, entry)
+  if not ok or type(decoded) ~= "table" then
+    return nil
   end
 
-  if compiler:match("clang") then
-    return "clang"
-  end
-
-  return nil
+  return M.classify_compiler(decoded.arguments or decoded.command)
 end
 
 --- Ensure compile_commands.json exists and was generated for clang
 function M.ensure_compile_commands(root)
   local path = compile_commands_path(root)
   if vim.fn.filereadable(path) == 0 then
-    vim.notify("[ESP32] ⚠️ Missing compile_commands.json in " .. path, vim.log.levels.WARN)
+    -- clangd drops --compile-commands-dir at startup when the directory is
+    -- absent ("The argument will be ignored"), so creating it later is not
+    -- enough on its own: the server has to be started again.
+    vim.notify(
+      "[ESP32] ⚠️ Missing compile_commands.json in " .. path
+        .. "\nclangd has already discarded the build directory for this session."
+        .. "\nRun :ESPReconfigure, which regenerates it and restarts clangd.",
+      vim.log.levels.WARN
+    )
     return
   end
 
@@ -281,6 +407,34 @@ function M.ensure_compile_commands(root)
       vim.log.levels.WARN
     )
   end
+end
+
+--- Restart the clangd clients of a project
+---
+--- Used after the build directory changes, because clangd only reads
+--- --compile-commands-dir at startup.
+function M.restart_clangd(root)
+  local restarted = false
+
+  for _, client in ipairs(vim.lsp.get_clients({ name = "clangd" })) do
+    if not root or client.root_dir == root then
+      local buffers = vim.lsp.get_buffers_by_client_id(client.id)
+      client:stop()
+      restarted = true
+
+      -- Re-attach once the old process is gone; the FileType autocmd is what
+      -- every LSP setup hangs its clangd config off.
+      vim.defer_fn(function()
+        for _, bufnr in ipairs(buffers) do
+          if vim.api.nvim_buf_is_valid(bufnr) then
+            vim.api.nvim_exec_autocmds("FileType", { buffer = bufnr })
+          end
+        end
+      end, 500)
+    end
+  end
+
+  return restarted
 end
 
 --- Projects already reported on, so one bad build dir warns once per session
@@ -387,11 +541,17 @@ function M.pick(cmd)
 end
 
 --- Run idf.py reconfigure for build.clang
+---
+--- clangd only reads --compile-commands-dir at startup, so a regenerated build
+--- directory does not reach a running server. Restart it once idf.py succeeds.
 function M.reconfigure()
   local Snacks = get_snacks()
+  local root = M.project_root()
+
   -- The build dir is about to change, so let it be reported on again.
   checked_roots = {}
-  Snacks.terminal.open(M.make_idf_command("-D IDF_TOOLCHAIN=clang reconfigure"), {
+
+  local terminal = Snacks.terminal.open(M.make_idf_command("-D IDF_TOOLCHAIN=clang reconfigure"), {
     win = {
       width = 0.5,
       height = 0.4,
@@ -399,18 +559,46 @@ function M.reconfigure()
       title_pos = "center",
     },
   })
+
+  local bufnr = type(terminal) == "table" and terminal.buf
+  if not bufnr then
+    return
+  end
+
+  vim.api.nvim_create_autocmd("TermClose", {
+    buffer = bufnr,
+    once = true,
+    callback = function()
+      if vim.v.event.status ~= 0 then
+        return
+      end
+
+      if M.restart_clangd(root) then
+        vim.notify("[ESP32] Reconfigured, restarting clangd.", vim.log.levels.INFO)
+      end
+    end,
+  })
 end
 
---- Set up ESP32 LSP configuration
-function M.lsp_config()
+--- Build the clangd command for a project root
+---
+--- Public so the resolved command stays inspectable: lsp_config() passes cmd as
+--- a function, which :checkhealth reports only as <function>.
+function M.clangd_cmd(root, opts)
   local clangd = M.find_esp_clangd()
   if not clangd then
-    vim.notify("[ESP32] No esp-clangd found. Falling back to system clangd.", vim.log.levels.WARN)
+    -- Reporting belongs to starting a server, not to inspecting the command.
+    if not (opts and opts.silent) then
+      vim.notify("[ESP32] No esp-clangd found. Falling back to system clangd.", vim.log.levels.WARN)
+    end
     clangd = "clangd"
   end
+
   local cmd = {
     clangd,
-    "--compile-commands-dir=" .. M.options.build_dir,
+    -- Absolute where a root is known: clangd resolves this against its own
+    -- working directory, which Neovim documents as unrelated to root_dir.
+    "--compile-commands-dir=" .. build_dir_for(root),
     "--background-index",
     "--clang-tidy",
     "--header-insertion=iwyu",
@@ -422,11 +610,27 @@ function M.lsp_config()
 
   vim.list_extend(cmd, M.options.clangd_args or {})
 
+  return cmd
+end
+
+--- Set up ESP32 LSP configuration
+function M.lsp_config()
   return {
-    cmd = cmd,
+    -- A function rather than a list so the build directory can be resolved
+    -- against the project root, which is only known once a client is created
+    -- for it. Same shape as nvim-lspconfig's own jsonls and ruby_lsp configs.
+    cmd = function(dispatchers, config)
+      local root = config and config.root_dir
+
+      return vim.lsp.rpc.start(M.clangd_cmd(root), dispatchers, {
+        cwd = (config and config.cmd_cwd) or root,
+        env = config and config.cmd_env,
+        detached = config and config.detached,
+      })
+    end,
     -- Prefer the ESP-IDF project root and avoid falling back to a parent git
     -- repository, which breaks nested projects/monorepos.
-    root_markers = { "sdkconfig", "CMakeLists.txt" },
+    root_markers = root_markers,
     capabilities = make_clangd_capabilities(),
     init_options = {
       usePlaceholders = true,
@@ -447,19 +651,25 @@ function M.info()
     table.insert(messages, "✗ ESP-specific clangd missing")
   end
 
-  -- compile_commands.json check
-  local build_dir = M.options.build_dir
-  local path = build_dir .. "/compile_commands.json"
+  -- compile_commands.json check, against the same project the LSP uses
+  local root = M.project_root()
+  local path = compile_commands_path(root)
   if vim.fn.filereadable(path) == 1 then
-    local toolchain = M.compile_commands_toolchain()
-    if toolchain == "gcc" then
+    local toolchain = M.compile_commands_toolchain(root)
+    if toolchain == "clang" then
+      table.insert(messages, "✓ compile_commands.json exists")
+    elseif toolchain == "gcc" then
       table.insert(messages, "✗ compile_commands.json was generated for GCC, run :ESPReconfigure")
     else
-      table.insert(messages, "✓ compile_commands.json exists")
+      -- Unrecognised is not the same as healthy; say so rather than imply a
+      -- clang database.
+      table.insert(messages, "? compile_commands.json exists, unrecognised compiler")
     end
   else
-    table.insert(messages, "✗ compile_commands.json missing")
+    table.insert(messages, "✗ compile_commands.json missing in " .. path)
   end
+
+  table.insert(messages, "clangd: " .. table.concat(M.clangd_cmd(root, { silent = true }), " "))
 
   -- Check ESP-IDF environment
   local function check_bin(bin)

--- a/nvim.log
+++ b/nvim.log
@@ -1,3 +1,0 @@
-WRN 2026-07-28T13:08:23.614 ?.27340    server_start:197: Failed to start server: operation not permitted: /var/folders/s_/tgp3r1sx6937cmq3zbfy527r0000gn/T/nvim.stefan/kIT4f1/nvim.27340.0
-WRN 2026-07-28T13:08:23.637 ?.27342    server_start:197: Failed to start server: operation not permitted: /var/folders/s_/tgp3r1sx6937cmq3zbfy527r0000gn/T/nvim.stefan/z5kuQJ/nvim.27342.0
-WRN 2026-07-28T13:08:44.629 ?.27382    server_start:197: Failed to start server: operation not permitted: /var/folders/s_/tgp3r1sx6937cmq3zbfy527r0000gn/T/nvim.stefan/YQgDZg/nvim.27382.0

--- a/nvim.log
+++ b/nvim.log
@@ -1,0 +1,3 @@
+WRN 2026-07-28T13:08:23.614 ?.27340    server_start:197: Failed to start server: operation not permitted: /var/folders/s_/tgp3r1sx6937cmq3zbfy527r0000gn/T/nvim.stefan/kIT4f1/nvim.27340.0
+WRN 2026-07-28T13:08:23.637 ?.27342    server_start:197: Failed to start server: operation not permitted: /var/folders/s_/tgp3r1sx6937cmq3zbfy527r0000gn/T/nvim.stefan/z5kuQJ/nvim.27342.0
+WRN 2026-07-28T13:08:44.629 ?.27382    server_start:197: Failed to start server: operation not permitted: /var/folders/s_/tgp3r1sx6937cmq3zbfy527r0000gn/T/nvim.stefan/YQgDZg/nvim.27382.0

--- a/tests/esp32_spec.lua
+++ b/tests/esp32_spec.lua
@@ -366,31 +366,54 @@ T["lsp_config() uses build_dir, root markers, and appends clangd_args"] = functi
   })
 
   local config = esp32.lsp_config()
+  local cmd = esp32.clangd_cmd()
 
-  expect.equality(config.cmd[1], esp32_path)
-  expect_truthy(vim.tbl_contains(config.cmd, "--compile-commands-dir=build.custom"))
-  expect_truthy(vim.tbl_contains(config.cmd, "--function-arg-placeholders=true"))
-  expect_truthy(vim.tbl_contains(config.cmd, "--query-driver=**"))
-  expect_truthy(vim.tbl_contains(config.cmd, "--enable-config"))
+  expect.equality(type(config.cmd), "function")
+  expect.equality(cmd[1], esp32_path)
+  expect_truthy(vim.tbl_contains(cmd, "--compile-commands-dir=build.custom"))
+  expect_truthy(vim.tbl_contains(cmd, "--function-arg-placeholders=true"))
+  expect_truthy(vim.tbl_contains(cmd, "--query-driver=**"))
+  expect_truthy(vim.tbl_contains(cmd, "--enable-config"))
   expect.equality(config.root_markers, { "sdkconfig", "CMakeLists.txt" })
   expect_truthy(config.capabilities ~= nil)
   expect.equality(config.capabilities.general.positionEncodings, { "utf-16" })
 end
 
-T["lsp_config() falls back to system clangd and warns when esp clangd is missing"] = function()
+T["clangd_cmd() falls back to system clangd and warns when esp clangd is missing"] = function()
   prepare_case()
   local esp32 = load_module()
   reset_plugin_state(esp32)
 
-  local config = esp32.lsp_config()
+  local cmd = esp32.clangd_cmd()
 
-  expect.equality(config.cmd[1], "clangd")
+  expect.equality(cmd[1], "clangd")
   expect.equality(#notifications, 1)
   expect.equality(
     notifications[1].message,
     "[ESP32] No esp-clangd found. Falling back to system clangd."
   )
   expect.equality(notifications[1].level, vim.log.levels.WARN)
+end
+
+T["clangd_cmd() stays quiet when only inspecting the command"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  local cmd = esp32.clangd_cmd(nil, { silent = true })
+
+  expect.equality(cmd[1], "clangd")
+  expect.equality(#notifications, 0)
+end
+
+T["clangd_cmd() makes the compile database absolute against a root"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  local cmd = esp32.clangd_cmd("/project/blink", { silent = true })
+
+  expect_truthy(vim.tbl_contains(cmd, "--compile-commands-dir=/project/blink/build.clang"))
 end
 
 T["setup() merges options and warns when esp clangd is missing"] = function()
@@ -422,10 +445,9 @@ T["ensure_compile_commands() warns when compile_commands.json is missing"] = fun
   esp32.ensure_compile_commands()
 
   expect.equality(#notifications, 1)
-  expect.equality(
-    notifications[1].message,
-    "[ESP32] ⚠️ Missing compile_commands.json in build.missing/compile_commands.json"
-  )
+  expect_truthy(notifications[1].message:match("Missing compile_commands%.json in build%.missing/compile_commands%.json"))
+  -- Regenerating alone is not enough: clangd already discarded the flag.
+  expect_truthy(notifications[1].message:match("restarts clangd"))
   expect.equality(notifications[1].level, vim.log.levels.WARN)
 end
 
@@ -445,6 +467,86 @@ T["compile_commands_toolchain() recognises a clang database"] = function()
   set_compile_commands("/opt/espressif/esp-clang/bin/clang")
 
   expect.equality(esp32.compile_commands_toolchain(), "clang")
+end
+
+T["classify_compiler() recognises the GCC variants ESP-IDF produces"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  local gcc = {
+    "/opt/esp/bin/xtensa-esp32-elf-gcc -c main.c",
+    "/opt/esp/bin/xtensa-esp32-elf-g++ -c main.cpp",
+    "/opt/esp/bin/riscv32-esp-elf-gcc -c main.c",
+    "gcc -c main.c",
+    "gcc.exe -c main.c",
+    "/usr/bin/cc -c main.c",
+    -- ESP-IDF puts ccache in front of the compiler when it is available.
+    "/usr/bin/ccache /opt/esp/bin/xtensa-esp32-elf-gcc -c main.c",
+    "sccache gcc -c main.c",
+    -- Windows toolchain paths containing spaces arrive quoted.
+    '"C:/Program Files/esp/xtensa-esp32-elf-gcc.exe" -c main.c',
+  }
+
+  for _, command in ipairs(gcc) do
+    expect.equality(esp32.classify_compiler(command), "gcc")
+  end
+end
+
+T["classify_compiler() recognises the clang variants"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  local clang = {
+    "/opt/esp/esp-clang/bin/clang -c main.c",
+    "/opt/esp/esp-clang/bin/clang++ -c main.cpp",
+    "clang.exe -c main.c",
+    "ccache /opt/esp/esp-clang/bin/clang -c main.c",
+    '"C:/Program Files/esp/clang.exe" -c main.c',
+  }
+
+  for _, command in ipairs(clang) do
+    expect.equality(esp32.classify_compiler(command), "clang")
+  end
+end
+
+T["classify_compiler() accepts the arguments list form"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  expect.equality(
+    esp32.classify_compiler({ "/opt/esp/bin/xtensa-esp32-elf-gcc", "-c", "main.c" }),
+    "gcc"
+  )
+  expect.equality(esp32.classify_compiler({ "ccache", "clang", "-c", "main.c" }), "clang")
+  expect.equality(esp32.classify_compiler({}), nil)
+  expect.equality(esp32.classify_compiler(nil), nil)
+  expect.equality(esp32.classify_compiler("/opt/rustc -c main.rs"), nil)
+end
+
+T["compile_commands_toolchain() reads a quoted Windows compiler path"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  vim.fn.filereadable = function(path)
+    return path:match("compile_commands%.json$") and 1 or 0
+  end
+  vim.fn.readfile = function()
+    return {
+      "[",
+      "{",
+      '  "directory": "C:/project/build.clang",',
+      '  "command": "\\"C:/Program Files/esp/xtensa-esp32-elf-gcc.exe\\" -c main.c",',
+      '  "file": "C:/project/main.c"',
+      "}",
+      "]",
+    }
+  end
+
+  expect.equality(esp32.compile_commands_toolchain(), "gcc")
 end
 
 T["compile_commands_toolchain() returns nil without a database"] = function()
@@ -639,7 +741,8 @@ T["info() reports idf.py available when an EIM Python command can be resolved"] 
   expect.equality(#notifications, 1)
   expect.equality(notifications[1].message, table.concat({
     "✗ ESP-specific clangd missing",
-    "✗ compile_commands.json missing",
+    "✗ compile_commands.json missing in build.clang/compile_commands.json",
+    "clangd: clangd --compile-commands-dir=build.clang --background-index --clang-tidy --header-insertion=iwyu --completion-style=detailed --function-arg-placeholders=true --fallback-style=llvm",
     "✓ idf.py",
     "✗ llvm-ar",
     "IDF_PATH: /home/test/.espressif/v6.0.1/esp-idf/v6.0.1/esp-idf",
@@ -671,6 +774,15 @@ T["info() reports project and environment status"] = function()
     end
     return 0
   end
+  vim.fn.readfile = function()
+    return {
+      "[",
+      "{",
+      '  "command": "/opt/espressif/esp-clang/bin/clang -c main.c"',
+      "}",
+      "]",
+    }
+  end
   vim.env.IDF_PATH = "/opt/esp-idf"
 
   local esp32 = load_module()
@@ -682,6 +794,7 @@ T["info() reports project and environment status"] = function()
   expect.equality(notifications[1].message, table.concat({
     "✓ Found esp-clangd",
     "✓ compile_commands.json exists",
+    "clangd: /opt/espressif/clangd --compile-commands-dir=build.clang --background-index --clang-tidy --header-insertion=iwyu --completion-style=detailed --function-arg-placeholders=true --fallback-style=llvm",
     "✓ idf.py",
     "✓ llvm-ar",
     "IDF_PATH: /opt/esp-idf",
@@ -698,7 +811,8 @@ T["info() suggests EIM and manual activation when ESP-IDF is not active"] = func
   expect.equality(notifications[1].level, vim.log.levels.INFO)
   expect.equality(notifications[1].message, table.concat({
     "✗ ESP-specific clangd missing",
-    "✗ compile_commands.json missing",
+    "✗ compile_commands.json missing in build.clang/compile_commands.json",
+    "clangd: clangd --compile-commands-dir=build.clang --background-index --clang-tidy --header-insertion=iwyu --completion-style=detailed --function-arg-placeholders=true --fallback-style=llvm",
     "✗ idf.py",
     "✗ llvm-ar",
     "IDF_PATH: ✗ not set",
@@ -726,7 +840,8 @@ T["info() suggests the PowerShell profile on Windows when ESP-IDF is not active"
   expect.equality(#notifications, 1)
   expect.equality(notifications[1].message, table.concat({
     "✗ ESP-specific clangd missing",
-    "✗ compile_commands.json missing",
+    "✗ compile_commands.json missing in build.clang/compile_commands.json",
+    "clangd: clangd --compile-commands-dir=build.clang --background-index --clang-tidy --header-insertion=iwyu --completion-style=detailed --function-arg-placeholders=true --fallback-style=llvm",
     "✗ idf.py",
     "✗ llvm-ar",
     "IDF_PATH: ✗ not set",

--- a/tests/esp32_spec.lua
+++ b/tests/esp32_spec.lua
@@ -480,6 +480,65 @@ T["ensure_compile_commands() stays quiet for a clang database"] = function()
   expect.equality(#notifications, 0)
 end
 
+T["compile_commands_toolchain() resolves build_dir against the project root"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  local checked
+  vim.fn.filereadable = function(path)
+    checked = path
+    return 0
+  end
+
+  esp32.compile_commands_toolchain("/project/blink")
+
+  expect.equality(checked, "/project/blink/build.clang/compile_commands.json")
+end
+
+T["compile_commands_toolchain() leaves an absolute build_dir alone"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+  esp32.options.build_dir = "/elsewhere/build"
+
+  local checked
+  vim.fn.filereadable = function(path)
+    checked = path
+    return 0
+  end
+
+  esp32.compile_commands_toolchain("/project/blink")
+
+  expect.equality(checked, "/elsewhere/build/compile_commands.json")
+end
+
+T["LspAttach checks the project clangd attached to, once per root"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+  set_compile_commands("/opt/espressif/bin/xtensa-esp32-elf-gcc")
+
+  local previous_get_client = vim.lsp.get_client_by_id
+  vim.lsp.get_client_by_id = function(id)
+    if id == 1 then
+      return { name = "clangd", root_dir = "/project/blink" }
+    end
+    return { name = "lua_ls", root_dir = "/project/blink" }
+  end
+
+  esp32.check_attached_client(1)
+  esp32.check_attached_client(1)
+  esp32.check_attached_client(2)
+
+  vim.lsp.get_client_by_id = previous_get_client
+
+  -- Same root twice and a non-clangd client must not add more warnings.
+  expect.equality(#notifications, 1)
+  expect_truthy(notifications[1].message:match("generated for the GCC toolchain"))
+  expect_truthy(notifications[1].message:match("^%[ESP32%].*/project/blink/build%.clang"))
+end
+
 T["make_idf_command() uses the EIM Python environment when idf.py is a shell function"] = function()
   prepare_case()
   vim.env.IDF_PATH = "/home/test/.espressif/v6.0.1/esp-idf/v6.0.1/esp-idf"

--- a/tests/esp32_spec.lua
+++ b/tests/esp32_spec.lua
@@ -109,7 +109,28 @@ local function prepare_case()
   vim.fn.expand = function()
     return "/home/test"
   end
+  vim.fn.readfile = function()
+    return {}
+  end
   set_scandir({})
+end
+
+--- Present a compile_commands.json whose first entry uses the given compiler
+local function set_compile_commands(compiler)
+  vim.fn.filereadable = function(path)
+    return path:match("compile_commands%.json$") and 1 or 0
+  end
+  vim.fn.readfile = function()
+    return {
+      "[",
+      "{",
+      '  "directory": "/project/build.clang",',
+      '  "command": "' .. compiler .. ' -DFOO -Iinclude -c main.c",',
+      '  "file": "/project/main/main.c"',
+      "}",
+      "]",
+    }
+  end
 end
 
 T.hooks = {
@@ -120,6 +141,7 @@ T.hooks = {
     original_fn.exepath = vim.fn.exepath
     original_fn.filereadable = vim.fn.filereadable
     original_fn.expand = vim.fn.expand
+    original_fn.readfile = vim.fn.readfile
     original_uv.fs_scandir = vim.uv.fs_scandir
     original_uv.fs_scandir_next = vim.uv.fs_scandir_next
   end,
@@ -136,6 +158,7 @@ T.hooks = {
     vim.fn.exepath = original_fn.exepath
     vim.fn.filereadable = original_fn.filereadable
     vim.fn.expand = original_fn.expand
+    vim.fn.readfile = original_fn.readfile
     vim.uv.fs_scandir = original_uv.fs_scandir
     vim.uv.fs_scandir_next = original_uv.fs_scandir_next
   end,
@@ -346,6 +369,7 @@ T["lsp_config() uses build_dir, root markers, and appends clangd_args"] = functi
 
   expect.equality(config.cmd[1], esp32_path)
   expect_truthy(vim.tbl_contains(config.cmd, "--compile-commands-dir=build.custom"))
+  expect_truthy(vim.tbl_contains(config.cmd, "--function-arg-placeholders=true"))
   expect_truthy(vim.tbl_contains(config.cmd, "--query-driver=**"))
   expect_truthy(vim.tbl_contains(config.cmd, "--enable-config"))
   expect.equality(config.root_markers, { "sdkconfig", "CMakeLists.txt" })
@@ -403,6 +427,57 @@ T["ensure_compile_commands() warns when compile_commands.json is missing"] = fun
     "[ESP32] ⚠️ Missing compile_commands.json in build.missing/compile_commands.json"
   )
   expect.equality(notifications[1].level, vim.log.levels.WARN)
+end
+
+T["compile_commands_toolchain() recognises a GCC database"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+  set_compile_commands("/opt/espressif/bin/xtensa-esp32-elf-gcc")
+
+  expect.equality(esp32.compile_commands_toolchain(), "gcc")
+end
+
+T["compile_commands_toolchain() recognises a clang database"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+  set_compile_commands("/opt/espressif/esp-clang/bin/clang")
+
+  expect.equality(esp32.compile_commands_toolchain(), "clang")
+end
+
+T["compile_commands_toolchain() returns nil without a database"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  expect.equality(esp32.compile_commands_toolchain(), nil)
+end
+
+T["ensure_compile_commands() warns when the database was generated for GCC"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+  set_compile_commands("/opt/espressif/bin/riscv32-esp-elf-gcc")
+
+  esp32.ensure_compile_commands()
+
+  expect.equality(#notifications, 1)
+  expect_truthy(notifications[1].message:match("generated for the GCC toolchain"))
+  expect_truthy(notifications[1].message:match("ESPReconfigure"))
+  expect.equality(notifications[1].level, vim.log.levels.WARN)
+end
+
+T["ensure_compile_commands() stays quiet for a clang database"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+  set_compile_commands("/opt/espressif/esp-clang/bin/clang")
+
+  esp32.ensure_compile_commands()
+
+  expect.equality(#notifications, 0)
 end
 
 T["make_idf_command() uses the EIM Python environment when idf.py is a shell function"] = function()

--- a/tests/esp32_spec.lua
+++ b/tests/esp32_spec.lua
@@ -641,6 +641,173 @@ T["LspAttach checks the project clangd attached to, once per root"] = function()
   expect_truthy(notifications[1].message:match("^%[ESP32%].*/project/blink/build%.clang"))
 end
 
+T["restart_clangd() replaces the matching client and reattaches its buffers"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  local previous_get_clients = vim.lsp.get_clients
+  local previous_start = vim.lsp.start
+  local previous_buf_is_valid = vim.api.nvim_buf_is_valid
+  local previous_schedule = vim.schedule
+  local matching_stopped = false
+  local other_stopped = false
+  local requested_filter
+  local starts = {}
+  local config = {
+    name = "clangd",
+    root_dir = "/project/blink",
+  }
+
+  vim.lsp.get_clients = function(filter)
+    requested_filter = filter
+    return {
+      {
+        root_dir = "/project/blink",
+        attached_buffers = { [12] = "c", [11] = "c" },
+        config = config,
+        stop = function()
+          matching_stopped = true
+        end,
+      },
+      {
+        root_dir = "/project/other",
+        stop = function()
+          other_stopped = true
+        end,
+      },
+    }
+  end
+  vim.api.nvim_buf_is_valid = function()
+    return true
+  end
+  vim.schedule = function(callback)
+    callback()
+  end
+  vim.lsp.start = function(client_config, opts)
+    table.insert(starts, { config = client_config, bufnr = opts.bufnr })
+    return 42
+  end
+
+  local restarted = esp32.restart_clangd("/project/blink")
+
+  vim.lsp.get_clients = previous_get_clients
+  vim.lsp.start = previous_start
+  vim.api.nvim_buf_is_valid = previous_buf_is_valid
+  vim.schedule = previous_schedule
+
+  expect.equality(restarted, true)
+  expect.equality(requested_filter, { name = "clangd" })
+  expect.equality(matching_stopped, true)
+  expect.equality(other_stopped, false)
+  expect.equality(starts, {
+    { config = config, bufnr = 11 },
+    { config = config, bufnr = 12 },
+  })
+end
+
+T["complete_reconfigure() closes a successful terminal and restarts clangd"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  local restarted_root
+  local closed = false
+  esp32.restart_clangd = function(root)
+    restarted_root = root
+    return true
+  end
+
+  local completed = esp32.complete_reconfigure("/project/blink", 0, {
+    close = function()
+      closed = true
+    end,
+  })
+
+  expect.equality(completed, true)
+  expect.equality(closed, true)
+  expect.equality(restarted_root, "/project/blink")
+  expect.equality(notifications, {
+    {
+      message = "[ESP32] Reconfigured, restarting clangd.",
+      level = vim.log.levels.INFO,
+    },
+  })
+end
+
+T["complete_reconfigure() keeps a failed terminal open and does not restart clangd"] = function()
+  prepare_case()
+  local esp32 = load_module()
+  reset_plugin_state(esp32)
+
+  local restarted = false
+  local closed = false
+  esp32.restart_clangd = function()
+    restarted = true
+    return true
+  end
+
+  local completed = esp32.complete_reconfigure("/project/blink", 2, {
+    close = function()
+      closed = true
+    end,
+  })
+
+  expect.equality(completed, false)
+  expect.equality(closed, false)
+  expect.equality(restarted, false)
+  expect.equality(notifications, {
+    {
+      message = "[ESP32] Reconfigure failed with exit code 2.\nCheck the terminal output.",
+      level = vim.log.levels.ERROR,
+    },
+  })
+end
+
+T["reconfigure() disables Snacks auto-close until its exit handler runs"] = function()
+  prepare_case()
+  local terminal_opts
+  local autocmd_spec
+  local terminal = { buf = 123 }
+  local esp32 = load_module({
+    terminal = {
+      open = function(_, opts)
+        terminal_opts = opts
+        return terminal
+      end,
+      toggle = function() end,
+    },
+    picker = {
+      pick = function() end,
+      util = {
+        align = function(value)
+          return value
+        end,
+      },
+    },
+  })
+  reset_plugin_state(esp32)
+  esp32.project_root = function()
+    return "/project/blink"
+  end
+
+  local previous_create_autocmd = vim.api.nvim_create_autocmd
+  vim.api.nvim_create_autocmd = function(event, spec)
+    autocmd_spec = vim.tbl_extend("force", { event = event }, spec)
+    return 1
+  end
+
+  esp32.reconfigure()
+
+  vim.api.nvim_create_autocmd = previous_create_autocmd
+
+  expect.equality(terminal_opts.auto_close, false)
+  expect.equality(autocmd_spec.event, "TermClose")
+  expect.equality(autocmd_spec.buffer, 123)
+  expect.equality(autocmd_spec.once, true)
+  expect.equality(type(autocmd_spec.callback), "function")
+end
+
 T["make_idf_command() uses the EIM Python environment when idf.py is a shell function"] = function()
   prepare_case()
   vim.env.IDF_PATH = "/home/test/.espressif/v6.0.1/esp-idf/v6.0.1/esp-idf"


### PR DESCRIPTION
Two clangd problems surfaced by #19, where the LSP looked broken but was actually being handed a build directory it could not use.

## `--function-arg-placeholders` needs an explicit boolean

clangd 20 rejects the bare flag:

```
E[12:31:53.690] Value specified by --function-arg-placeholders is invalid.
Provide a boolean value or leave unspecified to use ArgumentListsPolicy from config instead.
```

Now passed as `--function-arg-placeholders=true`.

## A GCC compile database reads as a broken LSP

`<leader>Rb` builds into `build_dir` with whatever toolchain is configured, so building before ever running `:ESPReconfigure` leaves a database generated for GCC in a clang-named directory. clangd then reports every ESP-IDF GCC flag as an unknown argument and cannot resolve newlib headers:

```
Unknown argument: '-fno-malloc-dce' / '-fno-shrink-wrap' / '-fno-tree-switch-conversion'
'sys/features.h' file not found
```

Nothing pointed at the real cause — `:ESPInfo` reported `✓ compile_commands.json exists`, because it only checked that the file was there.

`M.compile_commands_toolchain()` now identifies the compiler from the first entry of the database and returns `"clang"`, `"gcc"`, or `nil`. It reads only the first 40 lines rather than parsing the whole file, since these grow with the project and every entry shares a toolchain. An unrecognised format returns `nil` and warns about nothing.

## Wiring

`ensure_compile_commands()` was public but never called by the plugin, so neither check ran unless a user invoked it by hand. It now runs from `LspAttach`.

`LspAttach` rather than buffer open, because `build_dir` is relative by default: resolving it against Neovim's working directory would check the wrong path whenever Neovim was not started inside the project, and would fire on C files in unrelated projects. `client.root_dir` is the root clangd itself resolved, so the check looks exactly where clangd was pointed. An absolute `build_dir` is left alone.

It warns once per project root, ignores non-clangd clients, and `:ESPReconfigure` clears the cache so the next attach reports on the regenerated build directory instead of staying silent for the session.

For the setup in #19 this would have produced `⚠️ Missing compile_commands.json in .../build.clang` the moment clangd attached.

## Tests

30 cases, covering GCC/clang/unknown detection, root resolution, absolute `build_dir`, warn-once-per-root, and non-clangd clients. I confirmed the new cases genuinely assert by forcing each to fail and watching it get caught, and checked the autocmd end to end against a real file on disk.
